### PR TITLE
Updated the AndroidManifest.xml Path

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
 			</feature>
 		</config-file>
 
-		<config-file target="AndroidManifest.xml" parent="/manifest" mode="merge">
+		<config-file target="app/src/main/AndroidManifest.xml" parent="/manifest" mode="merge">
 			<uses-permission android:name="android.permission.BLUETOOTH" />
 			<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 		</config-file>


### PR DESCRIPTION
Since the release of Cordova Android 7.0.0, the path to AndroidManifest.xml has changed. This causes the plugin to throw error when installing the plugin